### PR TITLE
Add `GetActorValueIdFromName`

### DIFF
--- a/include/RE/M/Misc.h
+++ b/include/RE/M/Misc.h
@@ -21,4 +21,5 @@ namespace RE
 	bool     LookupReferenceByHandle(const RefHandle& a_handle, NiPointer<Actor>& a_refrOut);
 	bool     LookupReferenceByHandle(const RefHandle& a_handle, NiPointer<TESObjectREFR>& a_refrOut);
 	void     PlaySound(const char* a_editorID);
+	int32_t  GetActorValueIdFromName(const char* a_name);
 }

--- a/include/RE/Offsets.h
+++ b/include/RE/Offsets.h
@@ -487,6 +487,7 @@ namespace RE
 
 		inline REL::ID CreateRefHandle(RELOCATION_ID(12193, 12326));
 		inline REL::ID DebugNotification(RELOCATION_ID(52050, 52933));
+		inline REL::ID GetActorValueIdFromName(RELOCATION_ID(26570, 27203));
 		inline REL::ID LookupReferenceByHandle(RELOCATION_ID(12204, 12332));
 		inline REL::ID PlaySound(RELOCATION_ID(52054, 52939));
 		inline REL::ID TlsIndex(RELOCATION_ID(528600, 415542));

--- a/src/RE/M/Misc.cpp
+++ b/src/RE/M/Misc.cpp
@@ -107,4 +107,11 @@ namespace RE
 		REL::Relocation<func_t> func{ RELOCATION_ID(15779, 16017) };
 		return func(a_armorEntryData, a_armorPerks, a_skillMultiplier);
 	}
+	
+	std::int32_t GetActorValueIdFromName(const char* a_name)
+	{
+		using func_t = decltype(&GetActorValueIdFromName);
+		REL::Relocation<func_t> func{ Offset::GetActorValueIdFromName };
+		return func(a_name);
+	}
 }


### PR DESCRIPTION
I use this function in [LibFire](https://github.com/fireundubh/LibFire).

Usage example:
```cpp
if (const auto actor = a_ref->As<RE::Actor>(); actor) {
	const auto actorValueId = GetActorValueIdFromName(a_actorValue.c_str());  // <-- a_actorValue is of type RE::BSFixedString
	const auto actorValue = static_cast<RE::ActorValue>(actorValueId);
	return actor->GetPermanentActorValue(actorValue);
}
```