### PR TITLE
Fix Windows header include fragility, enable fmt/spdlog header-only f…

### DIFF
--- a/include/RE/B/BSFile.h
+++ b/include/RE/B/BSFile.h
@@ -31,22 +31,22 @@ namespace RE
 		virtual void Unk_12(void);  // 12
 
 		// members
-		bool          useAuxBuffer;                // 048
-		std::uint8_t  pad049;                      // 049
-		std::uint16_t pad04A;                      // 04A
-		std::uint32_t pad04C;                      // 04C
-		char*         auxBuffer;                   // 050
-		std::int32_t  auxTrueFilePos;              // 058
-		std::uint32_t auxBufferMinIndex;           // 05C
-		std::uint32_t auxBufferMaxIndex;           // 060
-		char          fileName[WinAPI::MAX_PATH];  // 064
-		std::uint32_t result;                      // 168
-		std::uint32_t ioSize;                      // 16C
-		std::uint32_t trueFilePos;                 // 170
-		std::uint32_t fileSize;                    // 174
-		bool          virtualAlloc;                // 178
-		std::uint8_t  unk179;                      // 179
-		std::uint16_t unk17A;                      // 17A
+		bool          useAuxBuffer;        // 048
+		std::uint8_t  pad049;              // 049
+		std::uint16_t pad04A;              // 04A
+		std::uint32_t pad04C;              // 04C
+		char*         auxBuffer;           // 050
+		std::int32_t  auxTrueFilePos;      // 058
+		std::uint32_t auxBufferMinIndex;   // 05C
+		std::uint32_t auxBufferMaxIndex;   // 060
+		char          fileName[MAX_PATH];  // 064
+		std::uint32_t result;              // 168
+		std::uint32_t ioSize;              // 16C
+		std::uint32_t trueFilePos;         // 170
+		std::uint32_t fileSize;            // 174
+		bool          virtualAlloc;        // 178
+		std::uint8_t  unk179;              // 179
+		std::uint16_t unk17A;              // 17A
 	};
 	static_assert(sizeof(BSFile) == 0x180);
 }

--- a/include/RE/B/BSSystemFile.h
+++ b/include/RE/B/BSSystemFile.h
@@ -21,9 +21,9 @@ namespace RE
 			BSSystemFile();
 
 			// members
-			std::uint32_t flags{ 1 };                            // 00
-			std::uint32_t pad04{ 0 };                            // 04
-			void*         file{ WinAPI::INVALID_HANDLE_VALUE };  // 08
+			std::uint32_t flags{ 1 };                    // 00
+			std::uint32_t pad04{ 0 };                    // 04
+			void*         file{ INVALID_HANDLE_VALUE };  // 08
 		};
 		static_assert(sizeof(BSSystemFile) == 0x10);
 	}

--- a/include/RE/B/BSTArray.h
+++ b/include/RE/B/BSTArray.h
@@ -600,7 +600,7 @@ namespace RE
 			if (oldData) {
 				const auto oldCapacity = capacity();
 				if (newData) {
-					const auto bytesToCopy = std::min(oldCapacity, a_newCapacity) * sizeof(value_type);
+					const auto bytesToCopy = (std::min)(oldCapacity, a_newCapacity) * sizeof(value_type);
 					std::memcpy(newData, oldData, bytesToCopy);
 				}
 				deallocate(oldData);

--- a/include/RE/B/BSTHashMap.h
+++ b/include/RE/B/BSTHashMap.h
@@ -338,7 +338,7 @@ namespace RE
 			const auto [newCap, newEntries] = [&]() {
 				constexpr std::uint64_t min = allocator_type::min_size();
 				static_assert(min > 0 && std::has_single_bit(min));
-				const auto cap = std::max(std::bit_ceil<std::uint64_t>(a_count), min);
+				const auto cap = (std::max)(std::bit_ceil<std::uint64_t>(a_count), min);
 				assert(cap >= min);
 				if (cap > 1u << 31) {
 					stl::report_and_fail("a buffer grew too large"sv);

--- a/include/RE/C/ColorUtil.h
+++ b/include/RE/C/ColorUtil.h
@@ -60,27 +60,27 @@ namespace RE
 					std::floor(a_rhs.blue));
 			}
 
-			inline NiColor min(const NiColor& a_lhs, const NiColor& a_rhs)
+			inline NiColor (min)(const NiColor& a_lhs, const NiColor& a_rhs)
 			{
 				return NiColor(
-					std::min(a_lhs.red, a_rhs.red),
-					std::min(a_lhs.green, a_rhs.green),
-					std::min(a_lhs.blue, a_rhs.blue));
+					(std::min)(a_lhs.red, a_rhs.red),
+					(std::min)(a_lhs.green, a_rhs.green),
+					(std::min)(a_lhs.blue, a_rhs.blue));
 			}
 
-			inline NiColor max(const NiColor& a_lhs, const NiColor& a_rhs)
+			inline NiColor (max)(const NiColor& a_lhs, const NiColor& a_rhs)
 			{
 				return NiColor(
-					std::max(a_lhs.red, a_rhs.red),
-					std::max(a_lhs.green, a_rhs.green),
-					std::max(a_lhs.blue, a_rhs.blue));
+					(std::max)(a_lhs.red, a_rhs.red),
+					(std::max)(a_lhs.green, a_rhs.green),
+					(std::max)(a_lhs.blue, a_rhs.blue));
 			}
 
 			// BLEND MODES
 
 			inline NiColor darken(const NiColor& a_src, const NiColor& a_dest)
 			{
-				return min(a_src, a_dest);
+				return (min)(a_src, a_dest);
 			}
 
 			inline NiColor multiply(const NiColor& a_src, const NiColor& a_dest)
@@ -105,7 +105,7 @@ namespace RE
 
 			inline NiColor lighten(const NiColor& a_src, const NiColor& a_dest)
 			{
-				return max(a_src, a_dest);
+				return (max)(a_src, a_dest);
 			}
 
 			inline NiColor screen(const NiColor& a_src, const NiColor& a_dest)

--- a/include/RE/F/FxResponseArgs.h
+++ b/include/RE/F/FxResponseArgs.h
@@ -50,7 +50,7 @@ namespace RE
 		using super = FxResponseArgsBase;
 		using container_type = std::array<GFxValue, N + O>;
 
-		static_assert(N + O <= static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max()));
+		static_assert(N + O <= static_cast<std::size_t>((std::numeric_limits<std::uint32_t>::max)()));
 
 	public:
 		using value_type = typename container_type::value_type;

--- a/include/RE/H/hkArray.h
+++ b/include/RE/H/hkArray.h
@@ -151,7 +151,7 @@ namespace RE
 			T*        newMem = static_cast<T*>(allocator->BufAlloc(newSize));
 			if (_data) {
 				size_type oldSize = size() * sizeof(T);
-				std::memcpy(newMem, _data, std::min(oldSize, newSize));
+				std::memcpy(newMem, _data, (std::min)(oldSize, newSize));
 				if ((_capacityAndFlags & kDontDeallocFlag) == 0) {
 					allocator->BufFree(_data, oldSize);
 				}

--- a/include/RE/L/LooseFileLocation.h
+++ b/include/RE/L/LooseFileLocation.h
@@ -11,11 +11,11 @@ namespace RE
 		{
 		public:
 			// members
-			void*                    handle;                     // 000
-			WinAPI::WIN32_FIND_DATAA findData;                   // 008
-			char                     dirPath[WinAPI::MAX_PATH];  // 148
-			ErrorCode                lastError;                  // 24C
-			std::uint64_t            entryPos;                   // 250
+			void*                    handle;             // 000
+			WinAPI::WIN32_FIND_DATAA findData;           // 008
+			char                     dirPath[MAX_PATH];  // 148
+			ErrorCode                lastError;          // 24C
+			std::uint64_t            entryPos;           // 250
 		};
 		static_assert(sizeof(BSSystemDir) == 0x258);
 

--- a/include/RE/N/NiStream.h
+++ b/include/RE/N/NiStream.h
@@ -57,40 +57,40 @@ namespace RE
 		virtual bool          LoadObjectSizeTable();                                    // 17
 
 		// members
-		BSStreamHeader                                header;                              // 008
-		BSTSmallArray<NiObjectGroup>                  groups;                              // 0D0
-		std::uint32_t                                 nifMaxVersion;                       // 100
-		std::uint32_t                                 nifMaxUserDefinedVersion;            // 104
-		char                                          inputFilePath[WinAPI::MAX_PATH];     // 108
-		std::uint16_t                                 unk20C;                              // 20C
-		std::uint16_t                                 unk20E;                              // 20E
-		std::uint64_t                                 unk210;                              // 210
-		NiTLargeObjectArray<NiPointer<NiObject>>      objects;                             // 218
-		NiTLargePrimitiveArray<std::uint32_t>         objectSizes;                         // 238
-		NiTLargeObjectArray<NiPointer<NiObject>>      topObjects;                          // 258
-		NiTLargeObjectArray<BSFixedString>            fixedStrings;                        // 278
-		NiBinaryStream*                               iStr;                                // 298
-		NiBinaryStream*                               oStr;                                // 2A0
-		std::uint32_t                                 linkIndex;                           // 2A8
-		std::uint32_t                                 linkBlockIndex;                      // 2AC
-		NiTPointerMap<NiObject const*, std::uint32_t> registerMap;                         // 2B0
-		std::uint16_t                                 niAVObjectFlags;                     // 2D0
-		std::uint16_t                                 niTimeControllerFlags;               // 2D2
-		std::uint16_t                                 niPropertyFlags;                     // 2D4
-		std::uint32_t                                 unk2D8;                              // 2D8
-		bool                                          unk2DC;                              // 2DC
-		std::uint32_t                                 load;                                // 2E0
-		std::uint32_t                                 link;                                // 2E4
-		std::uint32_t                                 postLink;                            // 2E8
-		std::uint64_t                                 unk2F0;                              // 2F0
-		std::uint64_t                                 unk2F8;                              // 2F8
-		std::uint32_t                                 unk300;                              // 300
-		std::uint32_t                                 unk304;                              // 304
-		std::int32_t                                  unk308;                              // 308
-		char                                          lastLoadedRTTI[WinAPI::MAX_PATH];    // 30C
-		std::uint32_t                                 lastError;                           // 410
-		char                                          lastErrorMessage[WinAPI::MAX_PATH];  // 414
-		char                                          filePath[WinAPI::MAX_PATH];          // 518
+		BSStreamHeader                                header;                      // 008
+		BSTSmallArray<NiObjectGroup>                  groups;                      // 0D0
+		std::uint32_t                                 nifMaxVersion;               // 100
+		std::uint32_t                                 nifMaxUserDefinedVersion;    // 104
+		char                                          inputFilePath[MAX_PATH];     // 108
+		std::uint16_t                                 unk20C;                      // 20C
+		std::uint16_t                                 unk20E;                      // 20E
+		std::uint64_t                                 unk210;                      // 210
+		NiTLargeObjectArray<NiPointer<NiObject>>      objects;                     // 218
+		NiTLargePrimitiveArray<std::uint32_t>         objectSizes;                 // 238
+		NiTLargeObjectArray<NiPointer<NiObject>>      topObjects;                  // 258
+		NiTLargeObjectArray<BSFixedString>            fixedStrings;                // 278
+		NiBinaryStream*                               iStr;                        // 298
+		NiBinaryStream*                               oStr;                        // 2A0
+		std::uint32_t                                 linkIndex;                   // 2A8
+		std::uint32_t                                 linkBlockIndex;              // 2AC
+		NiTPointerMap<NiObject const*, std::uint32_t> registerMap;                 // 2B0
+		std::uint16_t                                 niAVObjectFlags;             // 2D0
+		std::uint16_t                                 niTimeControllerFlags;       // 2D2
+		std::uint16_t                                 niPropertyFlags;             // 2D4
+		std::uint32_t                                 unk2D8;                      // 2D8
+		bool                                          unk2DC;                      // 2DC
+		std::uint32_t                                 load;                        // 2E0
+		std::uint32_t                                 link;                        // 2E4
+		std::uint32_t                                 postLink;                    // 2E8
+		std::uint64_t                                 unk2F0;                      // 2F0
+		std::uint64_t                                 unk2F8;                      // 2F8
+		std::uint32_t                                 unk300;                      // 300
+		std::uint32_t                                 unk304;                      // 304
+		std::int32_t                                  unk308;                      // 308
+		char                                          lastLoadedRTTI[MAX_PATH];    // 30C
+		std::uint32_t                                 lastError;                   // 410
+		char                                          lastErrorMessage[MAX_PATH];  // 414
+		char                                          filePath[MAX_PATH];          // 518
 	};
 	static_assert(sizeof(NiStream) == 0x620);
 }

--- a/include/RE/S/SFTypes.h
+++ b/include/RE/S/SFTypes.h
@@ -3,7 +3,7 @@
 namespace RE
 {
 	using UPInt = std::size_t;
-	constexpr UPInt UPINT_MAX = std::numeric_limits<UPInt>::max();
+	constexpr UPInt UPINT_MAX = (std::numeric_limits<UPInt>::max)();
 
 	using SPInt = std::ptrdiff_t;
 }

--- a/include/RE/S/ScrapHeap.h
+++ b/include/RE/S/ScrapHeap.h
@@ -38,7 +38,7 @@ namespace RE
 		};
 		static_assert(sizeof(FreeTreeNode) == 0x30);
 
-		~ScrapHeap() override { WinAPI::VirtualFree(baseAddress, 0, WinAPI::MEM_RELEASE); }  // 00
+		~ScrapHeap() override { WinAPI::VirtualFree(baseAddress, 0, MEM_RELEASE); }  // 00
 
 		// override (IMemoryStore)
 		std::size_t Size(void const* a_mem) const override { return *static_cast<const std::size_t*>(a_mem) & ~(std::size_t{ 3 } << 62); }  // 01

--- a/include/RE/T/TESFile.h
+++ b/include/RE/T/TESFile.h
@@ -77,8 +77,8 @@ namespace RE
 		TESBitArrayFile*                            formUserDataBitArray;             // 040
 		TESBitArrayFile*                            formVersionBitArray;              // 048
 		TESBitArrayFile*                            formIDBitArray;                   // 050
-		char                                        fileName[WinAPI::MAX_PATH];       // 058
-		char                                        path[WinAPI::MAX_PATH];           // 15C
+		char                                        fileName[MAX_PATH];               // 058
+		char                                        path[MAX_PATH];                   // 15C
 		char*                                       buffer;                           // 260
 		std::uint32_t                               bufferAllocSize;                  // 268
 		std::uint32_t                               firstCellOffset;                  // 26C

--- a/include/REL/Relocation.h
+++ b/include/REL/Relocation.h
@@ -348,7 +348,7 @@ namespace REL
 			WinAPI::VirtualProtect(
 				reinterpret_cast<void*>(a_dst),
 				a_count,
-				(WinAPI::PAGE_EXECUTE_READWRITE),
+				(PAGE_EXECUTE_READWRITE),
 				std::addressof(old));
 		if (success != 0) {
 			std::memcpy(reinterpret_cast<void*>(a_dst), a_src, a_count);
@@ -382,7 +382,7 @@ namespace REL
 			WinAPI::VirtualProtect(
 				reinterpret_cast<void*>(a_dst),
 				a_count,
-				(WinAPI::PAGE_EXECUTE_READWRITE),
+				(PAGE_EXECUTE_READWRITE),
 				std::addressof(old));
 		if (success != 0) {
 			std::fill_n(reinterpret_cast<std::uint8_t*>(a_dst), a_count, a_value);
@@ -503,18 +503,18 @@ namespace REL
 	[[nodiscard]] inline std::optional<Version> get_file_version(stl::zwstring a_filename)
 	{
 		std::uint32_t     dummy;
-		std::vector<char> buf(WinAPI::GetFileVersionInfoSize(a_filename.data(), std::addressof(dummy)));
+		std::vector<char> buf(GetFileVersionInfoSize(a_filename.data(), std::addressof(dummy)));
 		if (buf.empty()) {
 			return std::nullopt;
 		}
 
-		if (!WinAPI::GetFileVersionInfo(a_filename.data(), 0, static_cast<std::uint32_t>(buf.size()), buf.data())) {
+		if (!GetFileVersionInfo(a_filename.data(), 0, static_cast<std::uint32_t>(buf.size()), buf.data())) {
 			return std::nullopt;
 		}
 
 		void*         verBuf{ nullptr };
 		std::uint32_t verLen{ 0 };
-		if (!WinAPI::VerQueryValue(buf.data(), L"\\StringFileInfo\\040904B0\\ProductVersion", std::addressof(verBuf), std::addressof(verLen))) {
+		if (!VerQueryValue(buf.data(), L"\\StringFileInfo\\040904B0\\ProductVersion", std::addressof(verBuf), std::addressof(verLen))) {
 			return std::nullopt;
 		}
 
@@ -723,7 +723,7 @@ namespace REL
 		bool init()
 		{
 			const auto getFilename = [&]() {
-				return WinAPI::GetEnvironmentVariable(
+				return GetEnvironmentVariable(
 					ENVIRONMENT.data(),
 					_filename.data(),
 					static_cast<std::uint32_t>(_filename.size()));
@@ -736,7 +736,7 @@ namespace REL
 				result == 0) {
 				for (auto runtime : RUNTIMES) {
 					_filename = runtime;
-					moduleHandle = WinAPI::GetModuleHandle(_filename.c_str());
+					moduleHandle = GetModuleHandle(_filename.c_str());
 					if (moduleHandle) {
 						break;
 					}
@@ -807,13 +807,13 @@ namespace REL
 		void clear();
 
 		static constexpr std::array SEGMENTS{
-			std::make_pair(".text"sv, WinAPI::IMAGE_SCN_MEM_EXECUTE),
+			std::make_pair(".text"sv, IMAGE_SCN_MEM_EXECUTE),
 			std::make_pair(".idata"sv, static_cast<std::uint32_t>(0)),
 			std::make_pair(".rdata"sv, static_cast<std::uint32_t>(0)),
 			std::make_pair(".data"sv, static_cast<std::uint32_t>(0)),
 			std::make_pair(".pdata"sv, static_cast<std::uint32_t>(0)),
 			std::make_pair(".tls"sv, static_cast<std::uint32_t>(0)),
-			std::make_pair(".text"sv, WinAPI::IMAGE_SCN_MEM_WRITE),
+			std::make_pair(".text"sv, IMAGE_SCN_MEM_WRITE),
 			std::make_pair(".gfids"sv, static_cast<std::uint32_t>(0))
 		};
 
@@ -1693,7 +1693,7 @@ namespace REL
 				[[nodiscard]] constexpr std::byte hexacharacters_to_hexadecimal(char a_hi, char a_lo) noexcept
 				{
 					constexpr auto lut = []() noexcept {
-						std::array<std::uint8_t, std::numeric_limits<unsigned char>::max() + 1> a = {};
+						std::array<std::uint8_t, (std::numeric_limits<unsigned char>::max)() + 1> a = {};
 
 						const auto iterate = [&](std::uint8_t a_iFirst, unsigned char a_cFirst, unsigned char a_cLast) noexcept {
 							for (; a_cFirst <= a_cLast; ++a_cFirst, ++a_iFirst) {

--- a/include/SKSE/Impl/PCH.h
+++ b/include/SKSE/Impl/PCH.h
@@ -546,7 +546,7 @@ namespace SKSE
 		{
 			const auto cvt = [&](wchar_t* a_dst, std::size_t a_length) {
 				return WinAPI::MultiByteToWideChar(
-					WinAPI::CP_UTF8,
+					CP_UTF8,
 					0,
 					a_in.data(),
 					static_cast<int>(a_in.length()),
@@ -572,7 +572,7 @@ namespace SKSE
 		{
 			const auto cvt = [&](char* a_dst, std::size_t a_length) {
 				return WinAPI::WideCharToMultiByte(
-					WinAPI::CP_UTF8,
+					CP_UTF8,
 					0,
 					a_in.data(),
 					static_cast<int>(a_in.length()),
@@ -683,11 +683,11 @@ namespace SKSE
 				std::uint32_t result = 0;
 				do {
 					buf.resize(buf.size() * 2);
-					result = WinAPI::GetModuleFileName(
+					result = GetModuleFileName(
 						WinAPI::GetCurrentModule(),
 						buf.data(),
 						static_cast<std::uint32_t>(buf.size()));
-				} while (result && result == buf.size() && buf.size() <= std::numeric_limits<std::uint32_t>::max());
+				} while (result && result == buf.size() && buf.size() <= (std::numeric_limits<std::uint32_t>::max)());
 
 				if (result && result != buf.size()) {
 					std::filesystem::path p(buf.begin(), buf.begin() + result);
@@ -704,7 +704,7 @@ namespace SKSE
 					a_loc.function_name() },
 				spdlog::level::critical,
 				a_msg);
-			WinAPI::MessageBox(nullptr, body.c_str(), (caption.empty() ? nullptr : caption.c_str()), 0);
+			MessageBox(nullptr, body.c_str(), (caption.empty() ? nullptr : caption.c_str()), 0);
 			WinAPI::TerminateProcess(WinAPI::GetCurrentProcess(), EXIT_FAILURE);
 		}
 

--- a/include/SKSE/Impl/WinAPI.h
+++ b/include/SKSE/Impl/WinAPI.h
@@ -1,5 +1,23 @@
 #pragma once
 
+#undef CP_UTF8
+#undef IMAGE_SCN_MEM_EXECUTE
+#undef IMAGE_SCN_MEM_WRITE
+#undef INVALID_HANDLE_VALUE
+#undef MAX_PATH
+#undef MEM_COMMIT
+#undef MEM_RESERVE
+#undef MEM_RELEASE
+#undef PAGE_EXECUTE_READWRITE
+
+#undef GetEnvironmentVariable
+#undef GetFileVersionInfoSize
+#undef GetModuleFileName
+#undef VerQueryValue
+#undef GetFileVersionInfo
+#undef GetModuleHandle
+#undef MessageBox
+
 namespace SKSE::WinAPI
 {
 	inline constexpr auto CP_UTF8{ static_cast<unsigned int>(65001) };
@@ -7,6 +25,8 @@ namespace SKSE::WinAPI
 	inline constexpr auto IMAGE_SCN_MEM_WRITE{ static_cast<std::uint32_t>(0x80000000) };
 	inline const auto     INVALID_HANDLE_VALUE{ reinterpret_cast<void*>(static_cast<std::intptr_t>(-1)) };
 	inline constexpr auto MAX_PATH{ static_cast<std::uint32_t>(260) };
+	inline constexpr auto MEM_COMMIT{ static_cast<std::uint32_t>(0x00001000) };
+	inline constexpr auto MEM_RESERVE{ static_cast<std::uint32_t>(0x00002000) };
 	inline constexpr auto MEM_RELEASE{ static_cast<std::uint32_t>(0x00008000) };
 	inline constexpr auto PAGE_EXECUTE_READWRITE{ static_cast<std::uint32_t>(0x40) };
 
@@ -202,3 +222,21 @@ namespace RE::DirectX
 	};
 	static_assert(sizeof(XMFLOAT4X4) == 0x40);
 }
+
+#define CP_UTF8 ::SKSE::WinAPI::CP_UTF8
+#define IMAGE_SCN_MEM_EXECUTE ::SKSE::WinAPI::IMAGE_SCN_MEM_EXECUTE
+#define IMAGE_SCN_MEM_WRITE ::SKSE::WinAPI::IMAGE_SCN_MEM_WRITE
+#define INVALID_HANDLE_VALUE ::SKSE::WinAPI::INVALID_HANDLE_VALUE
+#define MAX_PATH ::SKSE::WinAPI::MAX_PATH
+#define MEM_COMMIT ::SKSE::WinAPI::MEM_COMMIT
+#define MEM_RESERVE ::SKSE::WinAPI::MEM_RESERVE
+#define MEM_RELEASE ::SKSE::WinAPI::MEM_RELEASE
+#define PAGE_EXECUTE_READWRITE ::SKSE::WinAPI::PAGE_EXECUTE_READWRITE
+
+#define GetEnvironmentVariable ::SKSE::WinAPI::GetEnvironmentVariable
+#define GetFileVersionInfoSize ::SKSE::WinAPI::GetFileVersionInfoSize
+#define GetModuleFileName ::SKSE::WinAPI::GetModuleFileName
+#define VerQueryValue ::SKSE::WinAPI::VerQueryValue
+#define GetFileVersionInfo ::SKSE::WinAPI::GetFileVersionInfo
+#define GetModuleHandle ::SKSE::WinAPI::GetModuleHandle
+#define MessageBox ::SKSE::WinAPI::MessageBox

--- a/include/SKSE/Trampoline.h
+++ b/include/SKSE/Trampoline.h
@@ -82,7 +82,7 @@ namespace SKSE
 
 			set_trampoline(mem, a_size,
 				[](void* a_mem, std::size_t) {
-					WinAPI::VirtualFree(a_mem, 0, WinAPI::MEM_RELEASE);
+					WinAPI::VirtualFree(a_mem, 0, MEM_RELEASE);
 				});
 		}
 
@@ -329,8 +329,8 @@ namespace SKSE
 
 		[[nodiscard]] bool in_range(std::ptrdiff_t a_disp) const
 		{
-			constexpr auto min = std::numeric_limits<std::int32_t>::min();
-			constexpr auto max = std::numeric_limits<std::int32_t>::max();
+			constexpr auto min = (std::numeric_limits<std::int32_t>::min)();
+			constexpr auto max = (std::numeric_limits<std::int32_t>::max)();
 
 			return min <= a_disp && a_disp <= max;
 		}

--- a/src/RE/A/Actor.cpp
+++ b/src/RE/A/Actor.cpp
@@ -843,7 +843,7 @@ namespace RE
 			kTotal
 		};
 
-		char addonString[WinAPI::MAX_PATH]{ '\0' };
+		char addonString[MAX_PATH]{ '\0' };
 		a_arma->GetNodeName(addonString, this, a_armor, -1);
 		std::array<NiAVObject*, kTotal> skeletonRoot = { Get3D(k3rd), Get3D(k1st) };
 		if (skeletonRoot[k1st] == skeletonRoot[k3rd]) {

--- a/src/RE/B/BGSDefaultObjectManager.cpp
+++ b/src/RE/B/BGSDefaultObjectManager.cpp
@@ -6,7 +6,7 @@ namespace RE
 {
 	namespace
 	{
-		constexpr auto kInvalid = std::numeric_limits<std::size_t>::max();
+		constexpr auto kInvalid = (std::numeric_limits<std::size_t>::max)();
 
 		inline std::size_t MapIndex(std::underlying_type_t<DefaultObjectID> a_idx) noexcept
 		{

--- a/src/RE/B/BGSSoundCategory.cpp
+++ b/src/RE/B/BGSSoundCategory.cpp
@@ -4,12 +4,12 @@ namespace RE
 {
 	float BGSSoundCategory::GetDefaultMenuValue() const
 	{
-		return static_cast<float>(defaultMenuValue / std::numeric_limits<std::uint16_t>::max());
+		return static_cast<float>(defaultMenuValue / (std::numeric_limits<std::uint16_t>::max)());
 	}
 
 	float BGSSoundCategory::GetStaticVolumeMultiplier() const
 	{
-		return static_cast<float>(staticMult / std::numeric_limits<std::uint16_t>::max());
+		return static_cast<float>(staticMult / (std::numeric_limits<std::uint16_t>::max)());
 	}
 
 	bool BGSSoundCategory::IsMenuCategory() const
@@ -19,11 +19,11 @@ namespace RE
 
 	void BGSSoundCategory::SetDefaultMenuValue(float a_val)
 	{
-		defaultMenuValue = static_cast<std::uint16_t>(a_val * std::numeric_limits<std::uint16_t>::max());
+		defaultMenuValue = static_cast<std::uint16_t>(a_val * (std::numeric_limits<std::uint16_t>::max)());
 	}
 
 	void BGSSoundCategory::SetStaticVolumeMultiplier(float a_val)
 	{
-		staticMult = static_cast<std::uint16_t>(a_val * std::numeric_limits<std::uint16_t>::max());
+		staticMult = static_cast<std::uint16_t>(a_val * (std::numeric_limits<std::uint16_t>::max)());
 	}
 }

--- a/src/RE/B/BSLightingShaderProperty.cpp
+++ b/src/RE/B/BSLightingShaderProperty.cpp
@@ -6,7 +6,7 @@ namespace RE
 	{
 		flags = a_other->flags;
 		alpha = a_other->alpha;
-		lastRenderPassState = std::numeric_limits<std::int32_t>::max();
+		lastRenderPassState = (std::numeric_limits<std::int32_t>::max)();
 		if (flags.all(EShaderPropertyFlag::kOwnEmit) && a_other->emissiveColor) {
 			if (!emissiveColor) {
 				emissiveColor = new NiColor();

--- a/src/RE/B/BSShaderProperty.cpp
+++ b/src/RE/B/BSShaderProperty.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	void BSShaderProperty::SetEffectShaderData(const BSTSmartPointer<BSEffectShaderData>& a_data)
 	{
-		lastRenderPassState = std::numeric_limits<std::int32_t>::max();
+		lastRenderPassState = (std::numeric_limits<std::int32_t>::max)();
 		effectData = a_data;
 	}
 

--- a/src/RE/C/ColorUtil.cpp
+++ b/src/RE/C/ColorUtil.cpp
@@ -78,7 +78,7 @@ namespace RE
 			}
 			color = detail::clamp(color, 0.0, 1.0);
 
-			return detail::mix(a_src, color, std::max(0.0f, a_alpha));
+			return detail::mix(a_src, color, (std::max)(0.0f, a_alpha));
 		}
 
 		float CalcLuminance(const NiColor& a_src)

--- a/src/RE/G/GFxMovieDef.cpp
+++ b/src/RE/G/GFxMovieDef.cpp
@@ -4,8 +4,8 @@ namespace RE
 {
 	GFxMovieDef::MemoryParams::MemoryParams(UPInt a_memoryArena) :
 		heapLimitMultiplier(0.25),
-		maxCollectionRoots(std::numeric_limits<std::uint32_t>::max()),
-		framesBetweenCollections(std::numeric_limits<std::uint32_t>::max()),
+		maxCollectionRoots((std::numeric_limits<std::uint32_t>::max)()),
+		framesBetweenCollections((std::numeric_limits<std::uint32_t>::max)()),
 		pad4C(0)
 	{
 		desc.arena = a_memoryArena;

--- a/src/RE/G/GFxWStringBuffer.cpp
+++ b/src/RE/G/GFxWStringBuffer.cpp
@@ -246,7 +246,7 @@ namespace RE
 		if (a_count <= _reserved.size) {
 			if (_text != _reserved.buffer) {
 				if (_text && _reserved.buffer) {
-					auto toCopy = std::min(_length, a_count);
+					auto toCopy = (std::min)(_length, a_count);
 					std::wmemcpy(_reserved.buffer, _text, toCopy);
 					GFREE(_text);
 				}
@@ -255,7 +255,7 @@ namespace RE
 		} else {
 			auto newText = alloc(a_count);
 			if (_text) {
-				auto toCopy = std::min(_length, a_count);
+				auto toCopy = (std::min)(_length, a_count);
 				std::wmemcpy(newText, _text, toCopy);
 				release();
 			}

--- a/src/RE/N/NiObjectNET.cpp
+++ b/src/RE/N/NiObjectNET.cpp
@@ -103,7 +103,7 @@ namespace RE
 			return nullptr;
 		}
 
-		assert(extraDataSize < std::numeric_limits<std::int16_t>::max());
+		assert(extraDataSize < (std::numeric_limits<std::int16_t>::max)());
 
 		std::int16_t bottom = 0;
 		std::int16_t top = static_cast<std::int16_t>(extraDataSize - 1);
@@ -225,7 +225,7 @@ namespace RE
 			return false;
 		}
 
-		assert(extraDataSize < std::numeric_limits<std::int16_t>::max());
+		assert(extraDataSize < (std::numeric_limits<std::int16_t>::max)());
 
 		std::int16_t bottom = 0;
 		std::int16_t top = static_cast<std::int16_t>(extraDataSize - 1);

--- a/src/RE/T/TESObjectARMA.cpp
+++ b/src/RE/T/TESObjectARMA.cpp
@@ -63,6 +63,6 @@ namespace RE
 		}
 
 		std::uint32_t sex = npc ? static_cast<std::uint32_t>(npc->GetSex()) : 0;
-		sprintf_s(a_dstBuff, WinAPI::MAX_PATH, " (%08X)[%d]/ (%08X) [%2.0f%%]", GetFormID(), sex, a_armor->GetFormID(), weight);
+		sprintf_s(a_dstBuff, MAX_PATH, " (%08X)[%d]/ (%08X) [%2.0f%%]", GetFormID(), sex, a_armor->GetFormID(), weight);
 	}
 }

--- a/src/RE/T/TESObjectWEAP.cpp
+++ b/src/RE/T/TESObjectWEAP.cpp
@@ -34,7 +34,7 @@ namespace RE
 
 	void TESObjectWEAP::GetNodeName(char* a_dstBuff) const
 	{
-		sprintf_s(a_dstBuff, WinAPI::MAX_PATH, "%s  (%08X)", "Weapon", formID);
+		sprintf_s(a_dstBuff, MAX_PATH, "%s  (%08X)", "Weapon", formID);
 	}
 
 	WEAPON_TYPE TESObjectWEAP::GetWeaponType() const

--- a/src/REL/Relocation.cpp
+++ b/src/REL/Relocation.cpp
@@ -162,7 +162,7 @@ namespace REL
 				 SEGMENTS.end(),
 				 [&](auto&& a_elem) {
                     constexpr auto size = std::extent_v<decltype(section.Name)>;
-                    const auto     len = std::min(a_elem.first.size(), size);
+                    const auto     len = (std::min)(a_elem.first.size(), size);
                     return std::memcmp(a_elem.first.data(), section.Name, len) == 0 &&
                            (section.Characteristics & a_elem.second) == a_elem.second;
                 });

--- a/src/SKSE/Trampoline.cpp
+++ b/src/SKSE/Trampoline.cpp
@@ -67,7 +67,7 @@ namespace SKSE
 	{
 		constexpr std::size_t    gigabyte = static_cast<std::size_t>(1) << 30;
 		constexpr std::size_t    minRange = gigabyte * 2;
-		constexpr std::uintptr_t maxAddr = std::numeric_limits<std::uintptr_t>::max();
+		constexpr std::uintptr_t maxAddr = (std::numeric_limits<std::uintptr_t>::max)();
 
 		::DWORD       granularity;
 		::SYSTEM_INFO si;


### PR DESCRIPTION
…or downstreams.

A common issue with new development on CommonLibSSE is that any Windows headers
must be included after the full set of CLibSSE headers. This can be an issue
if the end user is not aware of the limitation, or due to a common problem
with the Vcpkg port which causes it to erroneously use the header-only
deployment of spdlog, which is included through CommonLibSSE headers and in
header-only mode includes Windows headers.