### PR TITLE
Enable headless failures for unit testing in CI environments.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,12 @@ if(BUILD_TESTS)
 			cxx_std_23
 	)
 
+	target_compile_definitions(
+		"${PROJECT_NAME}Tests"
+		PUBLIC
+			ENABLE_COMMONLIBSSE_TESTING=1
+	)
+
 	if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 		target_compile_definitions(
 			"${PROJECT_NAME}Tests"

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ project root (next to `vcpkg.json`) with the following contents:
             "kind": "git",
             "repository": "https://gitlab.com/colorglass/vcpkg-colorglass",
             // Update this baseline to the latest commit from the above repo.
-            "baseline": "108a8b1a979f1fa4446cb5756af6b583d8491934",
+            "baseline": "1a1a3c1ff3fc853cf7adf8c3475109763011d906",
             "packages": [
                 "commonlibsse-ng",
                 "commonlibsse-ng-ae",

--- a/include/SKSE/Impl/PCH.h
+++ b/include/SKSE/Impl/PCH.h
@@ -152,7 +152,7 @@ namespace SKSE
 			string(const CharT (&)[N]) -> string<CharT, N - 1>;
 		}
 
-		template <class EF>                                    //
+		template <class EF>                                        //
 			requires(std::invocable<std::remove_reference_t<EF>>)  //
 		class scope_exit
 		{
@@ -241,7 +241,8 @@ namespace SKSE
 
 			template <class... Args>
 			constexpr enumeration(Args... a_values) noexcept  //
-				requires(std::same_as<Args, enum_type>&&...) :
+				requires(std::same_as<Args, enum_type> && ...)
+			:
 				_impl((static_cast<underlying_type>(a_values) | ...))
 			{}
 
@@ -270,7 +271,7 @@ namespace SKSE
 
 			template <class... Args>
 			constexpr enumeration& set(Args... a_args) noexcept  //
-				requires(std::same_as<Args, enum_type>&&...)
+				requires(std::same_as<Args, enum_type> && ...)
 			{
 				_impl |= (static_cast<underlying_type>(a_args) | ...);
 				return *this;
@@ -278,7 +279,7 @@ namespace SKSE
 
 			template <class... Args>
 			constexpr enumeration& reset(Args... a_args) noexcept  //
-				requires(std::same_as<Args, enum_type>&&...)
+				requires(std::same_as<Args, enum_type> && ...)
 			{
 				_impl &= ~(static_cast<underlying_type>(a_args) | ...);
 				return *this;
@@ -286,26 +287,26 @@ namespace SKSE
 
 			template <class... Args>
 			[[nodiscard]] constexpr bool any(Args... a_args) const noexcept  //
-				requires(std::same_as<Args, enum_type>&&...)
+				requires(std::same_as<Args, enum_type> && ...)
 			{
 				return (_impl & (static_cast<underlying_type>(a_args) | ...)) != static_cast<underlying_type>(0);
 			}
 
 			template <class... Args>
 			[[nodiscard]] constexpr bool all(Args... a_args) const noexcept  //
-				requires(std::same_as<Args, enum_type>&&...)
+				requires(std::same_as<Args, enum_type> && ...)
 			{
 				return (_impl & (static_cast<underlying_type>(a_args) | ...)) == (static_cast<underlying_type>(a_args) | ...);
 			}
 
 			template <class... Args>
 			[[nodiscard]] constexpr bool none(Args... a_args) const noexcept  //
-				requires(std::same_as<Args, enum_type>&&...)
+				requires(std::same_as<Args, enum_type> && ...)
 			{
 				return (_impl & (static_cast<underlying_type>(a_args) | ...)) == static_cast<underlying_type>(0);
 			}
 
-		private :
+		private:
 			underlying_type _impl{ 0 };
 		};
 
@@ -333,14 +334,14 @@ namespace SKSE
 #define SKSE_MAKE_ARITHMETIC_OP(a_op)                                                        \
 	template <class E, class U>                                                              \
 	[[nodiscard]] constexpr auto operator a_op(enumeration<E, U> a_enum, U a_shift) noexcept \
-		->enumeration<E, U>                                                                  \
+		-> enumeration<E, U>                                                                 \
 	{                                                                                        \
 		return static_cast<E>(static_cast<U>(a_enum.get()) a_op a_shift);                    \
 	}                                                                                        \
                                                                                              \
 	template <class E, class U>                                                              \
 	constexpr auto operator a_op##=(enumeration<E, U>& a_enum, U a_shift) noexcept           \
-		->enumeration<E, U>&                                                                 \
+		-> enumeration<E, U>&                                                                \
 	{                                                                                        \
 		return a_enum = a_enum a_op a_shift;                                                 \
 	}
@@ -348,42 +349,42 @@ namespace SKSE
 #define SKSE_MAKE_ENUMERATION_OP(a_op)                                                                      \
 	template <class E, class U1, class U2>                                                                  \
 	[[nodiscard]] constexpr auto operator a_op(enumeration<E, U1> a_lhs, enumeration<E, U2> a_rhs) noexcept \
-		->enumeration<E, std::common_type_t<U1, U2>>                                                        \
+		-> enumeration<E, std::common_type_t<U1, U2>>                                                       \
 	{                                                                                                       \
 		return static_cast<E>(static_cast<U1>(a_lhs.get()) a_op static_cast<U2>(a_rhs.get()));              \
 	}                                                                                                       \
                                                                                                             \
 	template <class E, class U>                                                                             \
 	[[nodiscard]] constexpr auto operator a_op(enumeration<E, U> a_lhs, E a_rhs) noexcept                   \
-		->enumeration<E, U>                                                                                 \
+		-> enumeration<E, U>                                                                                \
 	{                                                                                                       \
 		return static_cast<E>(static_cast<U>(a_lhs.get()) a_op static_cast<U>(a_rhs));                      \
 	}                                                                                                       \
                                                                                                             \
 	template <class E, class U>                                                                             \
 	[[nodiscard]] constexpr auto operator a_op(E a_lhs, enumeration<E, U> a_rhs) noexcept                   \
-		->enumeration<E, U>                                                                                 \
+		-> enumeration<E, U>                                                                                \
 	{                                                                                                       \
 		return static_cast<E>(static_cast<U>(a_lhs) a_op static_cast<U>(a_rhs.get()));                      \
 	}                                                                                                       \
                                                                                                             \
 	template <class E, class U1, class U2>                                                                  \
 	constexpr auto operator a_op##=(enumeration<E, U1>& a_lhs, enumeration<E, U2> a_rhs) noexcept           \
-		->enumeration<E, U1>&                                                                               \
+		-> enumeration<E, U1>&                                                                              \
 	{                                                                                                       \
 		return a_lhs = a_lhs a_op a_rhs;                                                                    \
 	}                                                                                                       \
                                                                                                             \
 	template <class E, class U>                                                                             \
 	constexpr auto operator a_op##=(enumeration<E, U>& a_lhs, E a_rhs) noexcept                             \
-		->enumeration<E, U>&                                                                                \
+		-> enumeration<E, U>&                                                                               \
 	{                                                                                                       \
 		return a_lhs = a_lhs a_op a_rhs;                                                                    \
 	}                                                                                                       \
                                                                                                             \
 	template <class E, class U>                                                                             \
 	constexpr auto operator a_op##=(E& a_lhs, enumeration<E, U> a_rhs) noexcept                             \
-		->E&                                                                                                \
+		-> E&                                                                                               \
 	{                                                                                                       \
 		return a_lhs = *(a_lhs a_op a_rhs);                                                                 \
 	}
@@ -391,14 +392,14 @@ namespace SKSE
 #define SKSE_MAKE_INCREMENTER_OP(a_op)                                                       \
 	template <class E, class U>                                                              \
 	constexpr auto operator a_op##a_op(enumeration<E, U>& a_lhs) noexcept                    \
-		->enumeration<E, U>&                                                                 \
+		-> enumeration<E, U>&                                                                \
 	{                                                                                        \
 		return a_lhs a_op## = static_cast<E>(1);                                             \
 	}                                                                                        \
                                                                                              \
 	template <class E, class U>                                                              \
 	[[nodiscard]] constexpr auto operator a_op##a_op(enumeration<E, U>& a_lhs, int) noexcept \
-		->enumeration<E, U>                                                                  \
+		-> enumeration<E, U>                                                                 \
 	{                                                                                        \
 		const auto tmp = a_lhs;                                                              \
 		a_op##a_op a_lhs;                                                                    \
@@ -524,7 +525,7 @@ namespace SKSE
 
 		template <class... Args>
 		[[nodiscard]] inline auto pun_bits(Args... a_args)  //
-			requires(std::same_as<std::remove_cv_t<Args>, bool>&&...)
+			requires(std::same_as<std::remove_cv_t<Args>, bool> && ...)
 		{
 			constexpr auto ARGC = sizeof...(Args);
 
@@ -654,7 +655,8 @@ namespace SKSE
 		};
 #endif
 
-		[[noreturn]] inline void report_and_fail(std::string_view a_msg, SKSE::stl::source_location a_loc = SKSE::stl::source_location::current())
+		inline bool report_and_error(std::string_view a_msg, bool a_fail = true,
+			SKSE::stl::source_location a_loc = SKSE::stl::source_location::current())
 		{
 			const auto body = [&]() -> std::wstring {
 				const std::filesystem::path p = a_loc.file_name();
@@ -704,8 +706,22 @@ namespace SKSE
 					a_loc.function_name() },
 				spdlog::level::critical,
 				a_msg);
-			MessageBox(nullptr, body.c_str(), (caption.empty() ? nullptr : caption.c_str()), 0);
-			WinAPI::TerminateProcess(WinAPI::GetCurrentProcess(), EXIT_FAILURE);
+
+			if (a_fail) {
+#ifdef ENABLE_COMMONLIBSSE_TESTING
+				throw std::runtime_error(utf16_to_utf8(caption.empty() ? body.c_str() : caption.c_str())->c_str());
+#else
+				MessageBox(nullptr, body.c_str(), (caption.empty() ? nullptr : caption.c_str()), 0);
+				WinAPI::TerminateProcess(WinAPI::GetCurrentProcess(), EXIT_FAILURE);
+#endif
+			}
+			return true;
+		}
+
+		[[noreturn]] inline void report_and_fail(std::string_view a_msg,
+			SKSE::stl::source_location a_loc = SKSE::stl::source_location::current())
+		{
+			report_and_error(a_msg, true, a_loc);
 		}
 
 		template <class Enum>
@@ -787,4 +803,4 @@ namespace REL
 #include "RE/B/BSCoreTypes.h"
 #include "RE/S/SFTypes.h"
 
-#undef cdecl // Workaround for Clang.
+#undef cdecl  // Workaround for Clang.

--- a/tests/REL/Relocation.test.cpp
+++ b/tests/REL/Relocation.test.cpp
@@ -257,3 +257,9 @@ TEST_CASE("Module/SupportsSkyrimVR")
 		REL::Module::reset();
 	}
 }
+
+TEST_CASE("IDDatabase/FailedIDLookup")
+{
+	REQUIRE(REL::Module::mock(SKSE::RUNTIME_SSE_1_6_353, REL::Module::Runtime::AE, L"SkyrimSE.exe", 0x1000));
+	REQUIRE_THROWS(REL::IDDatabase::get().id2offset(0xFFFFFFFF));
+}


### PR DESCRIPTION
Previously failed tests or negative test cases would freeze the test
job in GitHub Actions, due to them calling `MessageBox`, at which point
the job waits for a person to confirm the message. Even locally, the use
of `TerminateProcess` ended the testing.

With the use of `ENABLE_COMMONLIBSSE_TESTING` the behavior of a failure
changes to throwing an exception, which can be caught by negative test
cases, or results in a proper test failure.

This change also refactors the way in which `inject`/`mock` calls fail;
they still return a `bool` to indicate status but now log identically to
`report_and_fail`.