### PR TITLE
Integrate improved plugin declaration feature from Fully Dynamic Game Engine's Trueflame library.

### DIFF
--- a/cmake/testlist.cmake
+++ b/cmake/testlist.cmake
@@ -2,5 +2,6 @@ set(TESTS
     tests/RE/A/ActorValues.test.cpp
     tests/RE/F/FormTypes.test.cpp
     tests/REL/Relocation.test.cpp
+    tests/SKSE/Interfaces.test.cpp
     tests/SKSE/Trampoline.test.cpp
 )

--- a/include/REL/Relocation.h
+++ b/include/REL/Relocation.h
@@ -530,14 +530,6 @@ namespace REL
 	{
 		namespace detail
 		{
-			struct version_literal
-			{
-				version_literal(const char* str, std::size_t len)
-				{
-
-				}
-			};
-
 			template <std::size_t Index, char C>
 			constexpr uint8_t read_version(std::array<typename REL::Version::value_type, 4>& result) {
 				static_assert(C >= '0' && C <= '9', "Invalid character in semantic version literal.");

--- a/include/SKSE/Version.h
+++ b/include/SKSE/Version.h
@@ -2,34 +2,32 @@
 
 namespace SKSE
 {
-	using namespace REL::literals;
+	constexpr REL::Version RUNTIME_SSE_1_1_47(1, 1, 47, 0);
+	constexpr REL::Version RUNTIME_SSE_1_1_51(1, 1, 51, 0);
+	constexpr REL::Version RUNTIME_SSE_1_2_36(1, 2, 36, 0);
+	constexpr REL::Version RUNTIME_SSE_1_2_39(1, 2, 39, 0);
+	constexpr REL::Version RUNTIME_SSE_1_3_5(1, 3, 5, 0);
+	constexpr REL::Version RUNTIME_SSE_1_3_9(1, 3, 9, 0);
+	constexpr REL::Version RUNTIME_SSE_1_4_2(1, 4, 2, 0);
+	constexpr REL::Version RUNTIME_SSE_1_5_3(1, 5, 3, 0);
+	constexpr REL::Version RUNTIME_SSE_1_5_16(1, 5, 16, 0);
+	constexpr REL::Version RUNTIME_SSE_1_5_23(1, 5, 23, 0);
+	constexpr REL::Version RUNTIME_SSE_1_5_39(1, 5, 39, 0);
+	constexpr REL::Version RUNTIME_SSE_1_5_50(1, 5, 50, 0);
+	constexpr REL::Version RUNTIME_SSE_1_5_53(1, 5, 53, 0);
+	constexpr REL::Version RUNTIME_SSE_1_5_62(1, 5, 62, 0);
+	constexpr REL::Version RUNTIME_SSE_1_5_73(1, 5, 73, 0);
+	constexpr REL::Version RUNTIME_SSE_1_5_80(1, 5, 80, 0);
+	constexpr REL::Version RUNTIME_SSE_1_5_97(1, 5, 97, 0);
+	constexpr REL::Version RUNTIME_SSE_1_6_317(1, 6, 317, 0);
+	constexpr REL::Version RUNTIME_SSE_1_6_318(1, 6, 318, 0);
+	constexpr REL::Version RUNTIME_SSE_1_6_323(1, 6, 323, 0);
+	constexpr REL::Version RUNTIME_SSE_1_6_342(1, 6, 342, 0);
+	constexpr REL::Version RUNTIME_SSE_1_6_353(1, 6, 353, 0);
+	constexpr auto         RUNTIME_SSE_LATEST_AE = RUNTIME_SSE_1_6_353;
+	constexpr auto         RUNTIME__SSE_LATEST_SE = RUNTIME_SSE_1_5_97;
+	constexpr auto         RUNTIME__SSE_LATEST = RUNTIME_SSE_LATEST_AE;
 
-	constexpr auto RUNTIME_SSE_1_1_47 = "1.1.47.0"_v;
-	constexpr auto RUNTIME_SSE_1_1_51 = "1.1.51.0"_v;
-	constexpr auto RUNTIME_SSE_1_2_36 = "1.2.36.0"_v;
-	constexpr auto RUNTIME_SSE_1_2_39 = "1.2.39.0"_v;
-	constexpr auto RUNTIME_SSE_1_3_5 = "1.3.5.0"_v;
-	constexpr auto RUNTIME_SSE_1_3_9 = "1.3.9.0"_v;
-	constexpr auto RUNTIME_SSE_1_4_2 = "1.4.2.0"_v;
-	constexpr auto RUNTIME_SSE_1_5_3 = "1.5.3.0"_v;
-	constexpr auto RUNTIME_SSE_1_5_16 = "1.5.16.0"_v;
-	constexpr auto RUNTIME_SSE_1_5_23 = "1.5.23.0"_v;
-	constexpr auto RUNTIME_SSE_1_5_39 = "1.5.39.0"_v;
-	constexpr auto RUNTIME_SSE_1_5_50 = "1.5.50.0"_v;
-	constexpr auto RUNTIME_SSE_1_5_53 = "1.5.53.0"_v;
-	constexpr auto RUNTIME_SSE_1_5_62 = "1.5.62.0"_v;
-	constexpr auto RUNTIME_SSE_1_5_73 = "1.5.73.0"_v;
-	constexpr auto RUNTIME_SSE_1_5_80 = "1.5.80.0"_v;
-	constexpr auto RUNTIME_SSE_1_5_97 = "1.5.97.0"_v;
-	constexpr auto RUNTIME_SSE_1_6_317 = "1.6.317.0"_v;
-	constexpr auto RUNTIME_SSE_1_6_318 = "1.6.318.0"_v;
-	constexpr auto RUNTIME_SSE_1_6_323 = "1.6.323.0"_v;
-	constexpr auto RUNTIME_SSE_1_6_342 = "1.6.342.0"_v;
-	constexpr auto RUNTIME_SSE_1_6_353 = "1.6.353.0"_v;
-	constexpr auto RUNTIME_SSE_LATEST_AE = RUNTIME_SSE_1_6_353;
-	constexpr auto RUNTIME_SSE_LATEST_SE = RUNTIME_SSE_1_5_97;
-	constexpr auto RUNTIME_SSE_LATEST = RUNTIME_SSE_LATEST_AE;
-
-	constexpr auto RUNTIME_VR_1_4_15 = "1.4.15.0"_v;
-	constexpr auto RUNTIME_LATEST_VR = RUNTIME_VR_1_4_15;
+	constexpr REL::Version RUNTIME_VR_1_4_15(1, 4, 15, 0);
+	constexpr auto         RUNTIME_LATEST_VR = RUNTIME_VR_1_4_15;
 }

--- a/tests/SKSE/Interfaces.test.cpp
+++ b/tests/SKSE/Interfaces.test.cpp
@@ -1,0 +1,48 @@
+#include "catch.hpp"
+
+#include "REL/Relocation.h"
+#include "SKSE/SKSE.h"
+
+using namespace REL::literals;
+using namespace SKSE;
+
+namespace
+{
+	constinit PluginDeclaration WithAddressLibrary({ .Version = "1.2.3.4"_v,
+		.Name = "Plugin",
+		.RuntimeCompatibility = VersionIndependence::AddressLibrary });
+
+	constinit PluginDeclaration ForSpecificRuntimes({ .Version = "1.2.3.4"_v,
+		.Name = "Plugin",
+		.RuntimeCompatibility = { "1.5.97.0"_v, "1.6.353.0"_v } });
+
+	SKSEPluginInfo(.Version = "1.2.3.4"_v,
+		.Name = "Plugin")
+}
+
+TEST_CASE("PluginDeclaration/ConstinitDeclaration")
+{
+	SECTION("With address library")
+	{
+		CHECK(WithAddressLibrary.GetName() == "Plugin");
+		CHECK(WithAddressLibrary.GetVersion() == "1.2.3.4"_v);
+		CHECK(WithAddressLibrary.GetRuntimeCompatibility().IsVersionIndependent());
+		CHECK(WithAddressLibrary.GetRuntimeCompatibility().UsesAddressLibrary());
+		CHECK(!WithAddressLibrary.GetRuntimeCompatibility().UsesSignatureScanning());
+	}
+	SECTION("With specific runtime compatibility")
+	{
+		CHECK(ForSpecificRuntimes.GetName() == "Plugin");
+		CHECK(ForSpecificRuntimes.GetVersion() == "1.2.3.4"_v);
+		CHECK(!ForSpecificRuntimes.GetRuntimeCompatibility().IsVersionIndependent());
+		CHECK(!ForSpecificRuntimes.GetRuntimeCompatibility().UsesAddressLibrary());
+		CHECK(!ForSpecificRuntimes.GetRuntimeCompatibility().UsesSignatureScanning());
+		CHECK(static_cast<REL::Version>(ForSpecificRuntimes.GetRuntimeCompatibility().GetCompatibleRuntimeVersions()[0]) == "1.5.97.0"_v);
+		CHECK(static_cast<REL::Version>(ForSpecificRuntimes.GetRuntimeCompatibility().GetCompatibleRuntimeVersions()[1]) == "1.6.353.0"_v);
+	}
+	SECTION("Declared with SKSEPluginInfo")
+	{
+		CHECK(SKSEPlugin_Version.GetName() == "Plugin");
+		CHECK(SKSEPlugin_Version.GetVersion() == "1.2.3.4"_v);
+	}
+}


### PR DESCRIPTION
Trueflame includes a modernized and more semantically-defined API for defining a plugin.
Its system replaces PluginVersionData with a structure that is compatible but higher-level,
and enforces the logic behind things like the runtime compatibility more completely. It also
has a cleaner API that more concisely defines the plugin data without needing inline
lambda definitions/calls. The implementation here is based on Trueflame's but adds further
improvements from learnings from its use. Also added is a macro that can automatically
declare a comaptible `SKSEPlugin_Query` function, ensuring proper multi-targeting.