### PR TITLE
Add macro for simplified `SKSEPlugin_Load` declaration.

### DIFF
--- a/include/SKSE/Interfaces.h
+++ b/include/SKSE/Interfaces.h
@@ -639,3 +639,5 @@ namespace SKSE
 		pluginInfo->version = static_cast<std::uint32_t>(SKSEPlugin_Version.GetVersion().pack());                                                                   \
 		return true;                                                                                                                                                \
 	}
+
+#define SKSEPluginLoad(...) extern "C" [[maybe_unused]] __declspec(dllexport) bool SKSEPlugin_Load(__VA_ARGS__)


### PR DESCRIPTION
This follows the pattern of merging Fully Dynamic Game Engine structural
improvements, but FuDGE's system, while more powerful, is too opinionated
to belong in CommonLibSSE. Instead a simpler macro to cleanup the otherwise
unwieldy declaration.