### PR TITLE
Port FuDGE/Trueflame's CMake-based plugin declaration.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ if(BUILD_TESTS)
 		"${PROJECT_NAME}Tests"
 		PRIVATE
 			${PROJECT_NAME}
-			Catch2::Catch2
+			Catch2::Catch2WithMain
 	)
 
 	target_precompile_headers(

--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ features) when that runtime is present.
 [Read about multi-targeting, and how you can take advantage in your project.](
 https://github.com/CharmedBaryon/CommonLibSSE-NG/wiki/Runtime-Targeting)
 
+### Simplified Plugin Declaration
+![stability](https://img.shields.io/static/v1?label=stability&message=stable&color=dimgreen&style=flat)
+
+Historically, plugins needed to define `SKSEPlugin_Version` or `SKSEPlugin_Query` to be detected as SKSE plugins. To
+simplify code and ensure both functions are generated for correct cross-runtime compatibility, this is made code-free in
+CommonLibSSE NG. Just replace `add_library` with `add_commonlibsse_plugin` in `CMakeLists.txt` and CMake will create
+your shared library target, configure CommonLibSSE linkage, and auto-generate this content and inject it into the
+plugin.
+
+```cmake
+find_package(CommonLibSSE REQUIRED)
+
+add_commonlibsse_project(${PROJECT_NAME}
+    SOURCES ${headers} ${sources})
+```
+
 ### Clang Support
 ![stability-beta](https://img.shields.io/static/v1?label=stability&message=beta&color=yellow&style=flat)
 

--- a/cmake/CommonLibSSE.cmake
+++ b/cmake/CommonLibSSE.cmake
@@ -1,0 +1,124 @@
+function(commonlibsse_parse_version VERSION)
+    message("${version_match_count}")
+    string(REGEX MATCHALL "^([0-9]+)(\\.([0-9]+)(\\.([0-9]+)(\\.([0-9]+))?)?)?$" version_match "${VERSION}")
+    unset(COMMONLIBSSE_VERSION_MAJOR PARENT_SCOPE)
+    unset(COMMONLIBSSE_VERSION_MINOR PARENT_SCOPE)
+    unset(COMMONLIBSSE_VERSION_PATCH PARENT_SCOPE)
+    unset(COMMONLIBSSE_VERSION_TWEAK PARENT_SCOPE)
+
+    if ("${version_match} " STREQUAL " ")
+        set(COMMONLIBSSE_VERSION_MATCH FALSE PARENT_SCOPE)
+        return()
+    endif ()
+
+    set(COMMONLIBSSE_VERSION_MATCH TRUE PARENT_SCOPE)
+    set(COMMONLIBSSE_VERSION_MAJOR "${CMAKE_MATCH_1}" PARENT_SCOPE)
+    set(COMMONLIBSSE_VERSION_MINOR "0" PARENT_SCOPE)
+    set(COMMONLIBSSE_VERSION_PATCH "0" PARENT_SCOPE)
+    set(COMMONLIBSSE_VERSION_TWEAK "0" PARENT_SCOPE)
+
+    if (DEFINED CMAKE_MATCH_3)
+        set(COMMONLIBSSE_VERSION_MINOR "${CMAKE_MATCH_3}" PARENT_SCOPE)
+    endif ()
+    if (DEFINED CMAKE_MATCH_5)
+        set(COMMONLIBSSE_VERSION_PATCH "${CMAKE_MATCH_5}" PARENT_SCOPE)
+    endif ()
+    if (DEFINED CMAKE_MATCH_7)
+        set(COMMONLIBSSE_VERSION_TWEAK "${CMAKE_MATCH_7}" PARENT_SCOPE)
+    endif ()
+endfunction()
+
+function(add_commonlibsse_plugin TARGET)
+    set(options OPTIONAL USE_ADDRESS_LIBRARY USE_SIGNATURE_SCANNING EXCLUDE_FROM_ALL)
+    set(oneValueArgs NAME AUTHOR EMAIL VERSION MINIMUM_SKSE_VERSION)
+    set(multiValueArgs COMPATIBLE_RUNTIMES SOURCES)
+    cmake_parse_arguments(PARSE_ARGV 1 ADD_COMMONLIBSSE_PLUGIN "${options}" "${oneValueArgs}"
+            "${multiValueArgs}")
+
+    set(commonlibsse_plugin_file "${CMAKE_CURRENT_BINARY_DIR}/__${TARGET}Plugin.cpp")
+
+    # Set the plugin name.
+    set(commonlibsse_plugin_name "${TARGET}")
+    if (DEFINED ADD_COMMONLIBSSE_PLUGIN_NAME)
+        set(commonlibsse_plugin_name "${ADD_COMMONLIBSSE_PLUGIN_NAME}")
+    endif ()
+
+    # Setup version number of the plugin.
+    set(commonlibsse_plugin_version "${PROJECT_VERSION}")
+    if (DEFINED ADD_COMMONLIBSSE_PLUGIN_VERSION)
+        set(commonlibsse_plugin_version "ADD_COMMONLIBSSE_PLUGIN_NAME")
+    endif ()
+    commonlibsse_parse_version("${commonlibsse_plugin_version}")
+    if (NOT DEFINED COMMONLIBSSE_VERSION_MAJOR)
+        message(FATAL_ERROR "Unable to parse plugin version number ${commonlibsse_plugin_version}.")
+    endif ()
+    set(commonlibsse_plugin_version "REL::Version{ ${COMMONLIBSSE_VERSION_MAJOR}, ${COMMONLIBSSE_VERSION_MINOR}, ${COMMONLIBSSE_VERSION_PATCH}, ${COMMONLIBSSE_VERSION_TWEAK} }")
+
+    # Handle minimum SKSE version constraints.
+    if (NOT DEFINED ADD_COMMONLIBSSE_PLUGIN_MINIMUM_SKSE_VERSION)
+        set(ADD_COMMONLIBSSE_PLUGIN_MINIMUM_SKSE_VERSION 0)
+    endif ()
+    commonlibsse_parse_version("${ADD_COMMONLIBSSE_PLUGIN_MINIMUM_SKSE_VERSION}")
+    if (NOT COMMONLIBSSE_VERSION_MATCH)
+        message(FATAL_ERROR "Unable to parse SKSE minimum SKSE version number "
+                "${ADD_COMMONLIBSSE_PLUGIN_MINIMUM_SKSE_VERSION}.")
+    endif ()
+    set(commonlibsse_min_skse_version "REL::Version{ ${COMMONLIBSSE_VERSION_MAJOR}, ${COMMONLIBSSE_VERSION_MINOR}, ${COMMONLIBSSE_VERSION_PATCH}, ${COMMONLIBSSE_VERSION_TWEAK} }")
+
+    # Setup compatibility configuration.
+    if (NOT ADD_COMMONLIBSSE_PLUGIN_USE_SIGNATURE_SCANNING AND NOT DEFINED ADD_COMMONLIBSSE_PLUGIN_COMPATIBLE_RUNTIMES)
+        set(ADD_COMMONLIBSSE_PLUGIN_USE_ADDRESS_LIBRARY TRUE)
+    endif ()
+    if (ADD_COMMONLIBSSE_PLUGIN_USE_ADDRESS_LIBRARY OR ADD_COMMONLIBSSE_PLUGIN_USE_SIGNATURE_SCANNING)
+        if (DEFINED ADD_COMMONLIBSSE_PLUGIN_COMPATIBLE_RUNTIMES)
+            message(FATAL_ERROR "COMPATIBLE_RUNTIMES option should not be used with USE_ADDRESS_LIBRARY or "
+                    "USE_SIGNATURE_SCANNING")
+        endif ()
+
+        if (NOT ADD_COMMONLIBSSE_PLUGIN_USE_ADDRESS_LIBRARY)
+            set(commonlibsse_plugin_compatibility "VersionIndependence::SignatureScanning")
+        elseif (NOT ADD_COMMONLIBSSE_PLUGIN_USE_SIGNATURE_SCANNING)
+            set(commonlibsse_plugin_compatibility "SKSE::VersionIndependence::AddressLibrary")
+        else ()
+            set(commonlibsse_plugin_compatibility "SKSE::VersionIndependence::AddressLibraryAndSignatureScanning")
+        endif ()
+    else ()
+        list(LENGTH ${ADD_COMMONLIBSSE_PLUGIN_COMPATIBLE_RUNTIMES} commonlibsse_plugin_compatibility_count)
+        if(commonlibsse_plugin_compatibility_count GREATER 16)
+            message(FATAL_ERROR "No more than 16 version numbers can be provided for COMPATIBLE_RUNTIMES.")
+        endif()
+        foreach (SKYRIM_VERSION ${ADD_COMMONLIBSSE_PLUGIN_COMPATIBLE_RUNTIMES})
+            if (DEFINED commonlibsse_plugin_compatibility)
+                set(commonlibsse_plugin_compatibility "${commonlibsse_plugin_compatibility}, ")
+            endif ()
+            commonlibsse_parse_version("${SKYRIM_VERSION}")
+            if (NOT COMMONLIBSSE_VERSION_MATCH)
+                message(FATAL_ERROR "Unable to parse Skyrim runtime version number ${SKYRIM_VERSION}.")
+            endif ()
+            set(commonlibsse_plugin_compatibility "${commonlibsse_plugin_compatibility}REL::Version{ ${COMMONLIBSSE_VERSION_MAJOR}, ${COMMONLIBSSE_VERSION_MINOR}, ${COMMONLIBSSE_VERSION_PATCH}, ${COMMONLIBSSE_VERSION_TWEAK} }")
+        endforeach ()
+        set(commonlibsse_plugin_compatibility "{ ${commonlibsse_plugin_compatibility} }")
+    endif ()
+
+    file(WRITE "${commonlibsse_plugin_file}"
+            "#include \"REL/Relocation.h\"\n"
+            "#include \"SKSE/SKSE.h\"\n"
+            "\n"
+            "SKSEPluginInfo(\n"
+            "    .Version = ${commonlibsse_plugin_version},\n"
+            "    .Name = \"${commonlibsse_plugin_name}\"sv,\n"
+            "    .Author = \"${ADD_COMMONLIBSSE_PLUGIN_AUTHOR}\"sv,\n"
+            "    .SupportEmail = \"${ADD_COMMONLIBSSE_PLUGIN_EMAIL}\"sv,\n"
+            "    .RuntimeCompatibility = ${commonlibsse_plugin_compatibility},\n"
+            "    .MinimumSKSEVersion = ${commonlibsse_min_skse_version}\n"
+            ")\n")
+
+    add_library("${TARGET}" SHARED $<$<BOOL:${ADD_COMMONLIBSSE_PLUGIN_EXCLUDE_FROM_ALL}>:EXCLUDE_FROM_ALL>
+            ${ADD_COMMONLIBSSE_PLUGIN_SOURCES})
+
+    target_sources("${TARGET}" PRIVATE "${commonlibsse_plugin_file}")
+    target_compile_definitions("${TARGET}" PRIVATE __CMAKE_COMMONLIBSSE_PLUGIN=1)
+    target_link_libraries("${TARGET}" PRIVATE CommonLibSSE::CommonLibSSE)
+    set_property(TARGET "${TARGET}"
+            APPEND PROPERTY ADDITIONAL_CLEAN_FILES "${commonlibsse_plugin_file}")
+endfunction()

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -1,4 +1,5 @@
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 include(CMakeFindDependencyMacro)
 
 find_dependency(binary_io CONFIG)

--- a/tests/REL/Relocation.test.cpp
+++ b/tests/REL/Relocation.test.cpp
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 
 #include "REL/Relocation.h"

--- a/tests/SKSE/Interfaces.test.cpp
+++ b/tests/SKSE/Interfaces.test.cpp
@@ -24,7 +24,7 @@ TEST_CASE("PluginDeclaration/ConstinitDeclaration")
 {
 	SECTION("With address library")
 	{
-		CHECK(WithAddressLibrary.GetName() == "Plugin");
+		CHECK(std::string(WithAddressLibrary.GetName()) == "Plugin");
 		CHECK(WithAddressLibrary.GetVersion() == "1.2.3.4"_v);
 		CHECK(WithAddressLibrary.GetRuntimeCompatibility().IsVersionIndependent());
 		CHECK(WithAddressLibrary.GetRuntimeCompatibility().UsesAddressLibrary());
@@ -32,7 +32,7 @@ TEST_CASE("PluginDeclaration/ConstinitDeclaration")
 	}
 	SECTION("With specific runtime compatibility")
 	{
-		CHECK(ForSpecificRuntimes.GetName() == "Plugin");
+		CHECK(std::string(ForSpecificRuntimes.GetName()) == "Plugin");
 		CHECK(ForSpecificRuntimes.GetVersion() == "1.2.3.4"_v);
 		CHECK(!ForSpecificRuntimes.GetRuntimeCompatibility().IsVersionIndependent());
 		CHECK(!ForSpecificRuntimes.GetRuntimeCompatibility().UsesAddressLibrary());
@@ -42,7 +42,12 @@ TEST_CASE("PluginDeclaration/ConstinitDeclaration")
 	}
 	SECTION("Declared with SKSEPluginInfo")
 	{
-		CHECK(SKSEPlugin_Version.GetName() == "Plugin");
+		CHECK(std::string(SKSEPlugin_Version.GetName()) == "Plugin");
 		CHECK(SKSEPlugin_Version.GetVersion() == "1.2.3.4"_v);
 	}
+}
+
+TEST_CASE("PluginDeclaration/GetSingleton")
+{
+	CHECK(PluginDeclaration::GetSingleton() == &SKSEPlugin_Version);
 }


### PR DESCRIPTION
This is a more limited, CommonLibSSE-specific port of the Trueflame
feature. It allows using `add_commonlibsse_plugin` in place of
`add_library` in CMake, with additional options corresponding to the
plugin metadata. This results in the automatic generation and injection
into the project of `SKSEPlugin_Version` and `SKSEPlugin_Query`.