### PR TITLE
Fix providing explicit VERSION argument to add_commonlibsse_plugin

### DIFF
--- a/cmake/CommonLibSSE.cmake
+++ b/cmake/CommonLibSSE.cmake
@@ -47,7 +47,7 @@ function(target_commonlibsse_properties TARGET)
     # Setup version number of the plugin.
     set(commonlibsse_plugin_version "${PROJECT_VERSION}")
     if (DEFINED ADD_COMMONLIBSSE_PLUGIN_VERSION)
-        set(commonlibsse_plugin_version "ADD_COMMONLIBSSE_PLUGIN_NAME")
+        set(commonlibsse_plugin_version "${ADD_COMMONLIBSSE_PLUGIN_VERSION}")
     endif ()
     commonlibsse_parse_version("${commonlibsse_plugin_version}")
     if (NOT DEFINED COMMONLIBSSE_VERSION_MAJOR)


### PR DESCRIPTION
When providing a `VERSION` argument, I was getting:

> Unable to parse plugin version number ADD_COMMONLIBSSE_PLUGIN_NAME.