### PR TITLE
Add BSSoundHandle::Pause

### DIFF
--- a/include/RE/B/BSSoundHandle.h
+++ b/include/RE/B/BSSoundHandle.h
@@ -42,6 +42,7 @@ namespace RE
 		bool               SetVolume(float a_volume);
 		bool               Stop();
 		bool               Play();
+		bool			   Pause();
 
 		// members
 		std::uint32_t                                 soundID;        // 00

--- a/include/RE/Offsets.h
+++ b/include/RE/Offsets.h
@@ -143,6 +143,7 @@ namespace RE::Offset
 		constexpr auto Play = RELOCATION_ID(66355, 67616);
 		constexpr auto SetObjectToFollow = RELOCATION_ID(66375, 67636);
 		constexpr auto SetPosition = RELOCATION_ID(66370, 67631);
+		constexpr auto Pause = RELOCATION_ID(66357, 67618);
 		constexpr auto Stop = RELOCATION_ID(66358, 67619);
 	}
 

--- a/src/RE/B/BSSoundHandle.cpp
+++ b/src/RE/B/BSSoundHandle.cpp
@@ -81,4 +81,11 @@ namespace RE
 		REL::Relocation<func_t> func{ Offset::BSSoundHandle::Play };
 		return func(this);
 	}
+
+	bool BSSoundHandle::Pause()
+	{
+		using func_t = decltype(&BSSoundHandle::Pause);
+		REL::Relocation<func_t> func{ Offset::BSSoundHandle::Pause };
+		return func(this);
+	}
 }


### PR DESCRIPTION
Port BSSoundHandle::Pause from po3's fork (https://github.com/powerof3/CommonLibSSE/pull/101) to NG. Already verified the IDs / offsets in flatrim (po3's fork) and VR (https://github.com/alandtse/CommonLibVR/pull/34).

VR Address Library is missing BSSoundHandle::Pause, so this PR will not work with older versions of VR Address Library that do not have this commit https://github.com/alandtse/skyrim_vr_address_library/pull/52. Flatrim Address Library is fine.