### PR TITLE
Fix target_include_directories scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 
 find_package(fmt CONFIG REQUIRED)
 find_package(spdlog CONFIG REQUIRED)
-find_path(RAPIDCSV_INCLUDE_DIRS "rapidcsv.h")
+find_package(rapidcsv CONFIG REQUIRED)
 
 include(cmake/sourcelist.cmake)
 include(cmake/testlist.cmake)
@@ -116,14 +116,6 @@ target_include_directories(
 		"$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
-target_include_directories(
-	"${PROJECT_NAME}"
-	PUBLIC
-		${fmt_INCLUDE_DIRS}
-		${spdlog_INCLUDE_DIRS}
-		${RAPIDCSV_INCLUDE_DIRS}
-)
-
 target_compile_definitions(
 	"${PROJECT_NAME}"
 	PUBLIC
@@ -134,6 +126,7 @@ target_link_libraries(
 	PUBLIC
 		fmt::fmt
 		spdlog::spdlog
+		rapidcsv
 		Version.lib
 )
 
@@ -188,15 +181,6 @@ if(BUILD_TESTS)
 		PUBLIC
 			"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
 			"$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
-	)
-
-	target_include_directories(
-		"${PROJECT_NAME}Tests"
-		PRIVATE
-			${Catch2_INCLUDE_DIRS}
-			${fmt_INCLUDE_DIRS}
-			${spdlog_INCLUDE_DIRS}
-			${RAPIDCSV_INCLUDE_DIRS}
 	)
 
 	target_compile_definitions(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ option(SKSE_SUPPORT_XBYAK "Enables trampoline support for Xbyak." OFF)
 option(ENABLE_SKYRIM_SE "Enable support for Skyrim SE in the dynamic runtime feature." ON)
 option(ENABLE_SKYRIM_AE "Enable support for Skyrim AE in the dynamic runtime feature." ON)
 option(ENABLE_SKYRIM_VR "Enable support for Skyrim VR in the dynamic runtime feature." ON)
+option(COMMONLIBSSE_INSTALL "Enable installing the library." OFF)
 option(BUILD_TESTS "Enable building of the unit tests." ON)
 message("Options:")
 message("\tEnable Xbyak: ${SKSE_SUPPORT_XBYAK}")
@@ -136,35 +137,37 @@ target_precompile_headers(
 		include/SKSE/Impl/PCH.h
 )
 
-install(
-	TARGETS "${PROJECT_NAME}"
-	EXPORT "${PROJECT_NAME}-targets"
-)
+if(COMMONLIBSSE_INSTALL)
+	install(
+		TARGETS "${PROJECT_NAME}"
+		EXPORT "${PROJECT_NAME}-targets"
+	)
 
-install(
-	EXPORT "${PROJECT_NAME}-targets"
-	NAMESPACE "${PROJECT_NAME}::"
-	DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
-)
+	install(
+		EXPORT "${PROJECT_NAME}-targets"
+		NAMESPACE "${PROJECT_NAME}::"
+		DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+	)
 
-configure_file(
-	cmake/config.cmake.in
-	"${PROJECT_NAME}Config.cmake"
-	@ONLY
-)
+	configure_file(
+		cmake/config.cmake.in
+		"${PROJECT_NAME}Config.cmake"
+		@ONLY
+	)
 
-install(
-	FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-	DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
-)
+	install(
+		FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+		DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+	)
 
-install(
-	DIRECTORY
-		"include/RE"
-		"include/REL"
-		"include/SKSE"
-	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-)
+	install(
+		DIRECTORY
+			"include/RE"
+			"include/REL"
+			"include/SKSE"
+		DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+	)
+endif()
 
 if(BUILD_TESTS)
 	find_package(Catch2 CONFIG REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ target_include_directories(
 
 target_include_directories(
 	"${PROJECT_NAME}"
-	PRIVATE
+	PUBLIC
 		${fmt_INCLUDE_DIRS}
 		${spdlog_INCLUDE_DIRS}
 		${RAPIDCSV_INCLUDE_DIRS}


### PR DESCRIPTION
PRIVATE causes user cannot find rapidcsv, xbyak, etc.

Note: po3's fork use PUBLIC too.