### PR TITLE
Fix module handle error when using SKSE_RUNTIME env variable.

### DIFF
--- a/include/REL/Module.h
+++ b/include/REL/Module.h
@@ -294,6 +294,10 @@ namespace REL
 					}
 				}
 			}
+			else {
+				moduleHandle = REX::W32::GetModuleHandleW(_filename.c_str());
+			}
+			
 			_filePath = _filename;
 			if (!moduleHandle) {
 				stl::report_and_fail(

--- a/include/REL/Module.h
+++ b/include/REL/Module.h
@@ -295,6 +295,7 @@ namespace REL
 				}
 			}
 			else {
+				_filename.resize(_filename.size() - 1);
 				moduleHandle = REX::W32::GetModuleHandleW(_filename.c_str());
 			}
 			


### PR DESCRIPTION
Module doesn't invoke `GetModuleHandle` during init when SKSE_RUNTIME environment variable is set, thus raise error
![325491709-d899700b-35d5-4152-8f9a-687b92f1741e](https://github.com/CharmedBaryon/CommonLibSSE-NG/assets/18238047/baad3f62-e2ac-415c-81ab-b0ddee6ae4fb)
