### PR TITLE
Set a better default value for ADD_COMMONLIBSSE_PLUGIN_MINIMUM_SKSE_V…

### DIFF
--- a/cmake/CommonLibSSE.cmake
+++ b/cmake/CommonLibSSE.cmake
@@ -57,7 +57,7 @@ function(target_commonlibsse_properties TARGET)
 
     # Handle minimum SKSE version constraints.
     if (NOT DEFINED ADD_COMMONLIBSSE_PLUGIN_MINIMUM_SKSE_VERSION)
-        set(ADD_COMMONLIBSSE_PLUGIN_MINIMUM_SKSE_VERSION 0)
+        set(ADD_COMMONLIBSSE_PLUGIN_MINIMUM_SKSE_VERSION "0.0.0.0")
     endif ()
     commonlibsse_parse_version("${ADD_COMMONLIBSSE_PLUGIN_MINIMUM_SKSE_VERSION}")
     if (NOT COMMONLIBSSE_VERSION_MATCH)


### PR DESCRIPTION
After I upgraded to Visual Studio 17.10. The cmake script  generated weird `.MinimumSKSEVersion = REL::Version{ 0, , , 0 }`. I just give it a good default value to fix it.