### PR TITLE
Fix bad ptr deref in BGSDefaultObjectManager::GetObject/IsObjectInitialized

### DIFF
--- a/include/RE/B/BGSDefaultObjectManager.h
+++ b/include/RE/B/BGSDefaultObjectManager.h
@@ -1055,7 +1055,7 @@ namespace RE
 
 		[[nodiscard]] bool IsObjectInitialized(std::size_t a_idx) const noexcept
 		{
-			return REL::RelocateMember<bool*>(this, 0xB80, 0xBA8)[a_idx];
+			return (&REL::RelocateMember<bool>(this, 0xB80, 0xBA8))[a_idx];
 		}
 
 		[[nodiscard]] static bool SupportsVR(DefaultObjectID a_object) noexcept;

--- a/src/RE/B/BGSDefaultObjectManager.cpp
+++ b/src/RE/B/BGSDefaultObjectManager.cpp
@@ -30,7 +30,7 @@ namespace RE
 		if (idx == kInvalid) {
 			return nullptr;
 		}
-		return RelocateMember<bool*>(this, 0xB80, 0xBA8)[idx] ?
+		return (&RelocateMember<bool>(this, 0xB80, 0xBA8))[idx] ?
                    &RelocateMember<TESForm**>(this, 0x20, 0x20)[idx] :
                    nullptr;
 	}


### PR DESCRIPTION
In previous versions, the GetObject code could be summarized as:

    return objectInit[a_idx] ? objects[a_idx] : nullptr;

Where objectInit is an array that was at offset B80 in the struct. So the first item would be at 0xB80, the next at 0xB81...

Newer versions changed this to the following:

    return RelocateMember<bool*>(this, 0xB80, 0xBA8)[idx] ?
	    &RelocateMember<TESForm**>(this, 0x20, 0x20)[idx] :
	    nullptr;

in order to support VR.

The problem is that with RelocateMember it does not do the same thing as before, but rather the equivalent to the following:

    return (*objectInit)[a_idx] ? objects[a_idx] : nullptr;

That is, it reads whatever is in the first few byte of objectInit as a pointer, then adds the id to it and dereferences it, which causes a crash when the first few bytes are zero.

    Unhandled exception "EXCEPTION_ACCESS_VIOLATION" at 0x7FF89FD65339 ExtendedHotkeySystem.dll+0015339	cmp byte ptr [rcx+0x154], 0x00 |  C:\repos\SkyrimSE-Mods\projects\ExtendedHotkeySystem\src\Hooks_FavoritesHandler.cpp:16 ?IsPlayerVampire@EHKS@@YA_NXZ)

(0x154 here is kRaceVampire)

This commit changes it so it will work as before. Please review before pushing as I'm not very familiar with this codebase, but I can at least confirm the hotkey mod is not crashing anymore.

Probably fixes #66 .